### PR TITLE
Update edit test for many roles

### DIFF
--- a/spec/features/address/edit_address_spec.rb
+++ b/spec/features/address/edit_address_spec.rb
@@ -1,50 +1,84 @@
 require "rails_helper"
 
+describe "As a merchant" do
+  describe "when I visit my profile" do
+    it "can edit an address" do
+      merchant = User.create!(name: 'Merchant', address: '1111 Shop Rd', city: 'Chicago', state: 'IL', zip: 88888, email: 'merchant@merchant.com', password: 'securepassword', role: 1)
+
+      address_2 = merchant.addresses.create!(address: '1111 Shop Rd', city: 'Chicago', state: 'IL', zip: 88888)
+
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(merchant)
+
+      visit '/profile'
+
+      click_link 'Edit Address'
+
+      expect(page).to have_content("Edit Your Home Address")
+
+      fill_in :address, with: '567 State Ave'
+      fill_in :city, with: 'Denver'
+      fill_in :state, with: 'CO'
+      fill_in :zip, with: '80218'
+      fill_in :nickname, with: 'Home'
+      click_button 'Update Address'
+
+      expect(current_path).to eq('/profile')
+
+      expect(page).to have_content("You have updated your Home address")
+
+    # ask about why this fails!!!
+      # expect(page).to have_content('567 State Ave')
+      # expect(page).to have_content('Denver')
+      # expect(page).to have_content('CO')
+      # expect(page).to have_content('80218')
+      # expect(page).to have_content('Address Name: Home')
+      # expect(page).to have_link('Edit Address')
+    end
+  end
+end
+
 describe "As a user" do
   describe "when I visit my profile" do
     it "can edit an address" do
-      user = User.create!(name: 'Cliff Hanger', address: '123 Main St', city: 'Denver', state: 'CO', zip: 80218, email: 'cliff@example.com', password: 'securepassword')
-      address = user.addresses.create!(address: '123 Main St', city: 'Denver', state: 'CO', zip: 80218)
+      visit root_path
 
-      merchant = User.create!(name: 'Merchant', address: '1111 Shop Rd', city: 'Chicago', state: 'IL', zip: 88888, email: 'merchant@merchant.com', password: 'securepassword', role: 1)
-      address_2 = merchant.addresses.create!(address: '1111 Shop Rd', city: 'Chicago', state: 'IL', zip: 88888)
+      click_link 'Register'
 
-      lower_level_users = [user, merchant]
+      expect(current_path).to eq(registration_path)
 
-      lower_level_users.each do |user_or_merchant|
-        allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user_or_merchant)
+      fill_in 'Name', with: 'Cliff Hanger'
+      fill_in 'Address', with: '456 Mountain St'
+      fill_in 'City', with: 'Aspen'
+      fill_in 'State', with: 'CO'
+      fill_in 'Zip', with: '80218'
+      fill_in 'Email', with: 'aspenperson@email.com'
+      fill_in 'Password', with: 'securepassword'
+      fill_in 'Password confirmation', with: 'securepassword'
+      click_button 'Register'
 
-        address = user_or_merchant.addresses.last
+      visit '/profile'
 
-        visit '/profile'
+      click_link 'Edit Address'
 
-        within "#address-#{address.id}" do
-          click_link 'Edit Address'
-        end
+      expect(page).to have_content("Edit Your Home Address")
 
-        expect(page).to have_content("Edit Your #{address.nickname.capitalize} Address")
+      fill_in :address, with: '567 State Ave'
+      fill_in :city, with: 'Denver'
+      fill_in :state, with: 'CO'
+      fill_in :zip, with: '80218'
+      fill_in :nickname, with: 'Home'
+      click_button 'Update Address'
 
-        fill_in :address, with: '567 State Ave'
-        fill_in :city, with: 'Denver'
-        fill_in :state, with: 'CO'
-        fill_in :zip, with: '80218'
-        fill_in :nickname, with: 'Home'
-        click_button 'Update Address'
+      expect(current_path).to eq('/profile')
 
-        expect(current_path).to eq('/profile')
+      expect(page).to have_content("You have updated your Home address")
 
-        expect(page).to have_content("You have updated your #{address.nickname.capitalize} address")
-
-      # ask about why this fails!!!
-      # within "#address-#{address.id}" do
-      #   expect(page).to have_content('567 State Ave')
-      #   expect(page).to have_content('Denver')
-      #   expect(page).to have_content('CO')
-      #   expect(page).to have_content('80218')
-      #   expect(page).to have_content('Address Name: Home')
-      #   expect(page).to have_link('Edit Address')
-      # end
-      end
+      expect(page).to have_content('567 State Ave')
+      expect(page).to have_content('Denver')
+      expect(page).to have_content('CO')
+      expect(page).to have_content('80218')
+      expect(page).to have_content('Address Name: Home')
+      expect(page).to have_link('Edit Address')
     end
   end
 end


### PR DESCRIPTION
Update the edit address tests to check for both user and merchant roles. Admin cannot access that area as tested in the new spec.